### PR TITLE
Use native runners for ARM64 and AMD64 builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,32 +3,76 @@ on:
   push:
 jobs:
   build:
-    runs-on: ubuntu-latest
-
+    name: Build and push image (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: linux/amd64
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+            arch: arm64
     steps:
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-      with:
-        platforms: linux/arm64
+    - name: Checkout
+      uses: actions/checkout@v4
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-    - name: Docker Metadata action
-      id: metadata
-      uses: docker/metadata-action@v5
-      with:
-        images: |
-          ghcr.io/denkungsart/ci-ruby
-        tags: |
-          type=ref,event=branch
-    - name: Login to GitHub container registry
+    - name: Log in to Container Registry
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build and push
+    - name: Docker meta with arch suffix
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/denkungsart/ci-ruby
+        tags: |
+          type=ref,event=branch
+        flavor: |
+          suffix=-${{ matrix.arch }}
+    - name: Build and push (${{ matrix.platform }})
       uses: docker/build-push-action@v5
       with:
+        context: .
+        platforms: ${{ matrix.platform }}
         push: true
-        platforms: linux/amd64,linux/arm64
-        tags: ${{ steps.metadata.outputs.tags }}
+        tags: ${{ steps.meta.outputs.tags }}
+        cache-from: type=gha,scope=build-${{ matrix.platform }}
+        cache-to: type=gha,scope=build-${{ matrix.platform }},mode=max
+
+  manifest:
+    name: Create multi-arch manifest
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Log in to Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Docker meta (base tags)
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/denkungsart/ci-ruby
+        tags: |
+          type=ref,event=branch
+    - name: Create multi-arch manifests
+      run: |
+        tags="${{ steps.meta.outputs.tags }}"
+        while IFS= read -r tag; do
+          [ -z "$tag" ] && continue
+          echo "Creating manifest for $tag"
+          docker buildx imagetools create \
+            --tag "$tag" \
+            "${tag}-amd64" \
+            "${tag}-arm64"
+        done <<< "$tags"


### PR DESCRIPTION
Replace QEMU emulation with native runners using matrix strategy:
- AMD64 builds on ubuntu-latest
- ARM64 builds on ubuntu-24.04-arm

🤖 Generated with [Claude Code](https://claude.ai/code)

resolves GH-9